### PR TITLE
Fix overflow bug in gateway uptime calculation

### DIFF
--- a/SensorsGateway/SensorsGateway.ino
+++ b/SensorsGateway/SensorsGateway.ino
@@ -652,7 +652,7 @@ void readIds() {
 }
 
 void updateLastReceived() {
-  uint16_t currentTime = millis() / 60000; // Convert into minutes
+  uint32_t currentTime = millis() / 60000UL; // Convert into minutes
   gwMetaData.nodesDuringLastHour = 0;
   gwMetaData.nodesDuringLast12Hours = 0;
   gwMetaData.nodesDuringLast24Hours = 0;


### PR DESCRIPTION
Uptime calculation overflowed back to zero after 45.5 days = 1092 hours (2^16 / 60) because of wrong type of variable. After 49.7 days = 1193 hours (2^32 / 60000 / 60) uptime started working again due to millis() overflow compensation. This PR fixes this four day period during which gateway uptime was calculated wrong.