### PR TITLE
Add interrupt pin to gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Pulse nodes share the same board as gateway so they also have three LEDs. *PWR* 
 
 ## Headers, terminals and buttons
 
-Boards have a couple of user settable headers. These need to be set before boards are powered. Each device also has one button. In addition, gateway and pulse nodes have screw terminals.
+Boards have a couple of user settable headers. These need to be set before boards are powered. Each device also has one button. In addition, gateway and pulse nodes have screw terminals for power, serial communications and pulse inputs.
 
 ### Gateway
 
@@ -382,7 +382,7 @@ Button in gateway is currently not in use in normal operation. However, if you s
 * **A/RX** and **B/TX** are UART/RS-485 serial terminals.
 * Two **GND**s can be used as grounds for pulse inputs.
 * **P1** is the pulse 1 input.
-* **P2** is the pulse 2 input or external interrupt output, depending on the settings.
+* **P2** is the pulse 2 input or external interrupt output (active low open drain), depending on the settings.
 * **P3/NTC** is the pulse 3 input or NTC thermistor input, depending on the settings.
 
 ### Battery
@@ -394,7 +394,7 @@ Button in gateway is currently not in use in normal operation. However, if you s
 
 #### Button
 
-If button is pressed while applying power, a node is put into *debug mode*. In this mode, the node sends new values every 8 seconds with full power and also blinks the LED indicating success. Do not use in long-term as this will drain batteries quickly. Power cycle the node to cancel debug mode.
+If button is pressed while applying power, a node is put into *debug mode*. In this mode, the node sends new values every 8 seconds and also blinks the LED indicating success. Do not use in long-term as this will drain batteries quickly. Power cycle the node to cancel debug mode.
 
 During normal operation button triggers instant send with full power and blinks the LED indicating success. Use to quickly test if the node is within gateway's range.
 
@@ -408,7 +408,7 @@ During normal operation button triggers instant send with full power and blinks 
 
 #### Button
 
-If button is pressed while applying power, a node is put into *debug mode*. In this mode, the node sends new values every 8 seconds with full power. Do not use in long-term as this will unnecessarily congest radio network.
+If button is pressed while applying power, a node is put into *debug mode*. In this mode, the node sends new values every 8 seconds. Do not use in long-term as this will unnecessarily congest radio network.
 
 During normal operation button triggers instant send with full power. Use to quickly test if the node is within gateway's range. In addition, if you short **J1** and hold the button while powering on the node, saved pulse values in EEPROM will be set to zero.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ You could set the necessary fuses manually but it is considerably easier to just
 
 Gateway collects data from nodes and acts as an relay to a [Modbus](https://en.wikipedia.org/wiki/Modbus) network. By using Maxim Integrated MAX3485 RS-485 transceiver gateway can be connected to an existing RS-485 Modbus RTU network as a slave. Omitting the transceiver provides a direct TTL serial port. This can be accessed with, for example, another Arduino board, FTDI chip or connected directly to a Raspberry Pi. Regardless of the physical connection, gateway is accessed using Modbus protocol. Gateway requires regulated 3.3 volts or (unregulated) 5-12 volts DC power supply. In addition, gateway has three pulse inputs (pulse values are periodically saved to EEPROM and restored on power-up), one of which can be used as an NTC thermistor input. These inputs are also accessible via Modbus.
 
+One drawback of Modbus protocol is that a slave can not inform the master of new messages. For this, pulse 2 can be enabled to work as an external interrupt. This pin behaves like an emulated open collector output (external high state voltage is limited to 3.3 volts, however). The pin will be pulled to ground when a message is received either from an *important* node or any node, depending on the gateway settings. After Modbus read has been done, this pin will be set back to high impedance state.
+
 <p align="center"><img src="images/gateway_pcb.png" width="75%" /></p>
 
 **Warning:** UART serial port is 3.3 volts, so don't connect it to a 5 volt system.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Skip directly to [Instructions](#instructions), although I strongly recommend re
     * [Gateway](#gateway-1)
     * [Battery](#battery-2)
     * [Pulse / Pulse with Kamstrup Multical](#pulse--pulse-with-kamstrup-multical)
-  * [Headers, terminals and buttons](#headers--terminals-and-buttons)
+  * [Headers, terminals and buttons](#headers-terminals-and-buttons)
     * [Gateway](#gateway-2)
     * [Battery](#battery-3)
     * [Pulse / Pulse with Kamstrup Multical](#pulse--pulse-with-kamstrup-multical-1)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Why Modbus? Modbus is an easy to use and integrate protocol for this kind of dat
 
 ## Modbus registers
 
-Registers can be accessed using either function code 3 (read holding registers) or 4 (read input registers). Both return the same register values. Note that registers not defined can not be read. For example, trying to read registers 20-99 or 108-199 will return *illegal data address exception*.
+Registers can be accessed using either function code 3 (read holding registers) or 4 (read input registers). Both return the same register values. Note that registers not defined can not be read. For example, trying to read registers 21-99 or 108-199 will return *illegal data address exception*.
 
 ### Gateway specific registers
 
@@ -105,6 +105,7 @@ Registers can be accessed using either function code 3 (read holding registers) 
 | 14       | 30015  | Pulse 1 | Counter | 32 bit |
 | 16       | 30017  | Pulse 2 | Counter | 32 bit |
 | 18       | 30019  | Pulse 3 / Temperature | Counter / °C | 32 bit |
+| 20       | 30021  | Last received node ID |  |  |
 
 Status register bits (from LSB to MSB):
 * Bit 0 **External SRAM:** *1* if gateway has external SRAM, *0* if using internal SRAM. Affects maximum number of nodes, see notes in [Schematics and PCB](#schematics-and-pcb).
@@ -368,12 +369,12 @@ Boards have a couple of user settable headers. These need to be set before board
 #### Headers
 
 * **TERM** is 120 Ohm RS-485 termination resistor. Short if the gateway is in the very end of a long RS-485 line.
-* **J1** is currently not in use.
+* **J1** is currently not in normal use. See below for clearing old pulse values from EEPROM.
 * **NODE ID** sets 5 bit Modbus slave address.
 
 #### Button
 
-Button in gateway is currently not in use in normal operation. However, if you short **J1** and hold the button while powering on the gateway, saved pulse values will be set to zero.
+Button in gateway is currently not in use in normal operation. However, if you short **J1** and hold the button while powering on the gateway, saved pulse values in EEPROM will be set to zero.
 
 #### Terminals
 
@@ -388,24 +389,28 @@ Button in gateway is currently not in use in normal operation. However, if you s
 
 #### Headers
 
-* **J1** puts a node in *debug mode*. In this mode, the node sends new values every 8 seconds with full power and also blinks the LED indicating success. Do not use in long-term as this will drain batteries quickly.
+* **J1** marks a node *important*. When a node declares itself important to gateway, the gateway sets external interrupt pin to inform upstream device of received messages from important nodes.
 * **NODE ID** sets 6 bit address in radio network. Every node has to have a unique address.
 
 #### Button
 
-Button triggers instant send with full power and blinks the LED indicating success. Use to quickly test if the node is within gateway's range.
+If button is pressed while applying power, a node is put into *debug mode*. In this mode, the node sends new values every 8 seconds with full power and also blinks the LED indicating success. Do not use in long-term as this will drain batteries quickly. Power cycle the node to cancel debug mode.
+
+During normal operation button triggers instant send with full power and blinks the LED indicating success. Use to quickly test if the node is within gateway's range.
 
 ### Pulse / Pulse with Kamstrup Multical
 
 #### Headers
 
-* **TERM** is 120 Ohm RS-485 termination resistor. Short if the gateway is in the very end of a long RS-485 line.
-* **J1** puts a node in *debug mode*. In this mode, the node sends new values every 8 seconds with full power. Do not use in long-term as this will unnecessarily congest radio network.
+* **TERM** is 120 Ohm RS-485 termination resistor. Short if the node is in the very end of a long RS-485 line.
+* **J1** marks a node *important*. When a node declares itself important to gateway, the gateway sets external interrupt pin to inform upstream device of received messages from important nodes.
 * **NODE ID** sets 5 bit address in radio network. Every node has to have a unique address.
 
 #### Button
 
-Button triggers instant send with full power. Use to quickly test if the node is within gateway's range. In addition, if you short **J1** and hold the button while powering on the node, saved pulse values will be set to zero.
+If button is pressed while applying power, a node is put into *debug mode*. In this mode, the node sends new values every 8 seconds with full power. Do not use in long-term as this will unnecessarily congest radio network.
+
+During normal operation button triggers instant send with full power. Use to quickly test if the node is within gateway's range. In addition, if you short **J1** and hold the button while powering on the node, saved pulse values in EEPROM will be set to zero.
 
 #### Terminals
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Skip directly to [Instructions](#instructions), although I strongly recommend re
     * [Gateway](#gateway-1)
     * [Battery](#battery-2)
     * [Pulse / Pulse with Kamstrup Multical](#pulse--pulse-with-kamstrup-multical)
-  * [Headers and buttons](#headers-and-buttons)
+  * [Headers, terminals and buttons](#headers--terminals-and-buttons)
     * [Gateway](#gateway-2)
     * [Battery](#battery-3)
     * [Pulse / Pulse with Kamstrup Multical](#pulse--pulse-with-kamstrup-multical-1)
@@ -118,10 +118,17 @@ First address is *node id * 100*. For example, this table shows addresses for a 
 | 101       | 30102  | Battery voltage | mV | Current battery voltage. |
 | 102       | 30103  | Transmit power | % | Relative transmit power. |
 | 103       | 30104  | Transmit interval | Minute | How often the node transmits at least. |
-| 104       | 30105  | Header |  | Only 8 LSB, debug data. |
+| 104       | 30105  | Header |  | Only 8 LSB, debug data. See below for bits. |
 | 105       | 30106  | Temperature | °C | ×10 |
 | 106       | 30107  | Relative humidity | RH% | ×10. **Only if node has Si7021 or BME280.** |
 | 107       | 30108  | Barometric pressure / Temperature | hPa / °C | ×10. **Pressure if node has BME280, temperature if node has both Si7021 and NTC.** |
+
+Header register bits (from LSB to MSB):
+* Bit 0-2 **Node type:** Internal definiton of the node type.
+* Bit 3 **Reserved**
+* Bit 4 **Battery-powered:** *1* if node is battery-powered, *0* if powered externally.
+* Bit 5 **Important:** *1* if node has declared itself important, *0* if not.
+* Bit 6-7 **Reserved**
 
 ### Pulse node specific registers
 
@@ -132,10 +139,17 @@ First address is *node id * 100*. For example, this table shows addresses for a 
 | 200       | 30201  | Last received | Minute | When was node last seen. |
 | 201       | 30202  | Transmit power | % | Relative transmit power. |
 | 202       | 30203  | Transmit interval | Minute | How often the node transmits at least. |
-| 203       | 30204  | Header |  | Only 8 LSB, debug data. |
+| 203       | 30204  | Header |  | Only 8 LSB, debug data. See below for bits. |
 | 204       | 30205  | Pulse 1 | Counter | 32 bit |
 | 206       | 30207  | Pulse 2 | Counter | 32 bit |
 | 208       | 30209  | Pulse 3 / Temperature | Counter / °C | 32 bit |
+
+Header register bits (from LSB to MSB):
+* Bit 0-2 **Node type:** Internal definiton of the node type.
+* Bit 3 **Reserved**
+* Bit 4 **Battery-powered:** *1* if node is battery-powered, *0* if powered externally.
+* Bit 5 **Important:** *1* if node has declared itself important, *0* if not.
+* Bit 6-7 **Reserved**
 
 ### Pulse node with Kamstrup Multical 602 energy meter specific registers
 
@@ -146,7 +160,7 @@ First address is *node id * 100*. For example, this table shows addresses for a 
 | 300       | 30301  | Last received | Minute | When was node last seen. |
 | 301       | 30302  | Transmit power | % | Relative transmit power. |
 | 302       | 30303  | Transmit interval | Minute | How often the node transmits at least. |
-| 303       | 30304  | Header |  | Only 8 LSB, debug data. |
+| 303       | 30304  | Header |  | Only 8 LSB, debug data. See below for bits. |
 | 304       | 30305  | Pulse 1 | Counter | 32 bit |
 | 306       | 30307  | Pulse 2 | Counter | 32 bit |
 | 308       | 30309  | Pulse 3 / Temperature | Counter / °C | 32 bit |
@@ -156,6 +170,13 @@ First address is *node id * 100*. For example, this table shows addresses for a 
 | 316       | 30317  | Actual power | kW | ×10. 32 bit |
 | 318       | 30319  | Actual t₁ | °C | ×100. 32 bit |
 | 320       | 30321  | Actual t₂ | °C | ×100. 32 bit |
+
+Header register bits (from LSB to MSB):
+* Bit 0-2 **Node type:** Internal definiton of the node type.
+* Bit 3 **Reserved**
+* Bit 4 **Battery-powered:** *1* if node is battery-powered, *0* if powered externally.
+* Bit 5 **Important:** *1* if node has declared itself important, *0* if not.
+* Bit 6-7 **Reserved**
 
 # Node types
 
@@ -336,37 +357,62 @@ Pulse nodes share the same board as gateway so they also have three LEDs. *PWR* 
 | 3 | - | Successful Modbus read. | Operation |  |
 | 4 | - | Failed Modbus read. | Operation |  |
 
-## Headers and buttons
+## Headers, terminals and buttons
 
-Boards have a couple of user settable headers. These need to be set before boards are powered. Each device also has one button.
+Boards have a couple of user settable headers. These need to be set before boards are powered. Each device also has one button. In addition, gateway and pulse nodes have screw terminals.
 
 ### Gateway
 
-**TERM** is 120 Ohm RS-485 termination resistor. Short if the gateway is in the very end of a long RS-485 line.
+#### Headers
 
-**J1** is currently not in use.
+* **TERM** is 120 Ohm RS-485 termination resistor. Short if the gateway is in the very end of a long RS-485 line.
+* **J1** is currently not in use.
+* **NODE ID** sets 5 bit Modbus slave address.
 
-**NODE ID** sets 5 bit Modbus slave address.
+#### Button
 
-**Button** is currently not in use.
+Button in gateway is currently not in use in normal operation. However, if you short **J1** and hold the button while powering on the gateway, saved pulse values will be set to zero.
+
+#### Terminals
+
+* **+** and **-** are the 5-12 volts DC power inputs.
+* **A/RX** and **B/TX** are UART/RS-485 serial terminals.
+* Two **GND**s can be used as grounds for pulse inputs.
+* **P1** is the pulse 1 input.
+* **P2** is the pulse 2 input or external interrupt output, depending on the settings.
+* **P3/NTC** is the pulse 3 input or NTC thermistor input, depending on the settings.
 
 ### Battery
 
-**J1** puts a node in *debug mode*. In this mode, the node sends new values every 8 seconds with full power and also blinks the LED indicating success. Do not use in long-term as this will drain batteries quickly.
+#### Headers
 
-**NODE ID** sets 6 bit address in radio network. Every node has to have a unique address.
+* **J1** puts a node in *debug mode*. In this mode, the node sends new values every 8 seconds with full power and also blinks the LED indicating success. Do not use in long-term as this will drain batteries quickly.
+* **NODE ID** sets 6 bit address in radio network. Every node has to have a unique address.
 
-**Button** triggers instant send with full power and blinks the LED indicating success. Use to quickly test if the node is within gateway's range.
+#### Button
+
+Button triggers instant send with full power and blinks the LED indicating success. Use to quickly test if the node is within gateway's range.
 
 ### Pulse / Pulse with Kamstrup Multical
 
-**TERM** is 120 Ohm RS-485 termination resistor. Short if the gateway is in the very end of a long RS-485 line.
+#### Headers
 
-**J1** puts a node in *debug mode*. In this mode, the node sends new values every 8 seconds with full power. Do not use in long-term as this will unnecessarily congest radio network.
+* **TERM** is 120 Ohm RS-485 termination resistor. Short if the gateway is in the very end of a long RS-485 line.
+* **J1** puts a node in *debug mode*. In this mode, the node sends new values every 8 seconds with full power. Do not use in long-term as this will unnecessarily congest radio network.
+* **NODE ID** sets 5 bit address in radio network. Every node has to have a unique address.
 
-**NODE ID** sets 5 bit address in radio network. Every node has to have a unique address.
+#### Button
 
-**Button** triggers instant send with full power. Use to quickly test if the node is within gateway's range.
+Button triggers instant send with full power. Use to quickly test if the node is within gateway's range. In addition, if you short **J1** and hold the button while powering on the node, saved pulse values will be set to zero.
+
+#### Terminals
+
+* **+** and **-** are the 5-12 volts DC power inputs.
+* **A/RX** and **B/TX** are UART/RS-485 serial terminals.
+* Two **GND**s can be used as grounds for pulse inputs.
+* **P1** is the pulse 1 input.
+* **P2** is the pulse 2 input.
+* **P3/NTC** is the pulse 3 input or NTC thermistor input, depending on the settings.
 
 # Instructions
 

--- a/SensorsGateway/SensorsGateway.ino
+++ b/SensorsGateway/SensorsGateway.ino
@@ -158,6 +158,7 @@ struct {
   volatile uint32_t pulse3;
   bool outOfMemory;
   uint16_t uptime;
+  uint8_t lastRcvdNode;
 } gwMetaData;
 
 // Various variables
@@ -374,6 +375,9 @@ void checkRadio() {
           // Blink led to indicate received and successfully saved message
           setBlink(1);
           
+          // Set last received node id to gateway metadata
+          gwMetaData.lastRcvdNode = from;
+          
           // Set external interrupt pin if it is in use
           #ifdef ENABLE_EXT_INTERRUPT
             // If pin is to be used only with nodes marked as important
@@ -448,7 +452,7 @@ void checkModbus() {
     // Calculate how many registers it is possible to read based on type
     uint8_t maxNrOfRegistersToRead = 0;
     if (requestedType == 0) {
-      maxNrOfRegistersToRead = 20;
+      maxNrOfRegistersToRead = 21;
     }
     else if (requestedType == 1) {
       maxNrOfRegistersToRead = 8;
@@ -504,6 +508,8 @@ void checkModbus() {
       payloadBuffer[37] = (gwMetaData.pulse3 >> 16);
       payloadBuffer[38] = (gwMetaData.pulse3 >> 8);
       payloadBuffer[39] = gwMetaData.pulse3;
+      payloadBuffer[40] = 0;
+      payloadBuffer[41] = gwMetaData.lastRcvdNode;
     }
     // Battery type
     else if (requestedType == 1) {

--- a/SensorsGateway/SensorsGateway.ino
+++ b/SensorsGateway/SensorsGateway.ino
@@ -54,6 +54,21 @@
 #define DELETE_OLD_NODES  0
 
 /*
+ * ### EXTERNAL INTERRUPT ###
+ *
+ * Select if pulse 2 is used as an interrupt to inform upstream device of new messages.
+ *
+ * Define ENABLE_EXT_INTERRUPT if you want this feature to be enabled, otherwise comment it out.
+ * Define EXT_INTERRUPT_ONLY_IMPORTANT if you want that only nodes which declare themselves as important
+ * trigger external interrupt. Otherwise every new message will trigger the interrupt.
+ * Define EXT_INTERRUPT_USE_INT_PULLUP to use internal (weak) Atmega328P pull-up resistor, otherwise
+ * make sure to have pull-up resistor in the upstream device.
+ */
+#define ENABLE_EXT_INTERRUPT
+#define EXT_INTERRUPT_ONLY_IMPORTANT
+#define EXT_INTERRUPT_USE_INT_PULLUP
+
+/*
  * ####################
  * ### END SETTINGS ###
  * ####################
@@ -61,7 +76,7 @@
 
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION 3
+#define MINOR_VERSION 4
 
 #include <SimpleModbusAsync.h>
 #include <RH_RF95.h>
@@ -178,7 +193,9 @@ void setup() {
   
   // Pulse inputs
   pinMode(P1_PIN, INPUT_PULLUP);
+  #ifndef ENABLE_EXT_INTERRUPT
   pinMode(P2_PIN, INPUT_PULLUP);
+  #endif
   if (!hasNTC) {
     pinMode(P3_PIN, INPUT_PULLUP);
   }
@@ -220,7 +237,11 @@ void setup() {
   if (!hasNTC) {
     PCICR |= B00000010; // P3 (port C)
   }
+  #ifdef ENABLE_EXT_INTERRUPT
+  PCMSK2 |= B01000000;  // P1
+  #else
   PCMSK2 |= B11000000;  // P1 and P2
+  #endif
   if (!hasNTC) {
     PCMSK1 |= B00000010;  // P3
   }
@@ -232,6 +253,11 @@ void setup() {
   
   // Initialize memory handler
   memoryHandler.init();
+  
+  // Initialize external interrupt pin if in use
+  #ifdef ENABLE_EXT_INTERRUPT
+  setExternalInterrupt(false);
+  #endif
 }
 
 void loop() {
@@ -310,6 +336,9 @@ void checkRadio() {
       
       // If the message was from a known type node, save it to memory
       if (length != 0) {
+        
+        // Check if the node is marked as important
+        bool isImportant = payloadBuffer[0] & B00100000;
 
         // Reuse the same payloadBuffer to save SRAM
         
@@ -344,6 +373,19 @@ void checkRadio() {
           
           // Blink led to indicate received and successfully saved message
           setBlink(1);
+          
+          // Set external interrupt pin if it is in use
+          #ifdef ENABLE_EXT_INTERRUPT
+            // If pin is to be used only with nodes marked as important
+            #ifdef EXT_INTERRUPT_ONLY_IMPORTANT
+            if (isImportant) {
+              setExternalInterrupt(true);
+            }
+            // Else always set the pin
+            #else
+            setExternalInterrupt(true);
+            #endif
+          #endif
         }
       }
     }
@@ -593,6 +635,11 @@ void checkModbus() {
         
         // Blink led to indicate successful Modbus read
         setBlink(3);
+        
+        // Clear external interrupt pin if it was in use
+        #ifdef ENABLE_EXT_INTERRUPT
+        setExternalInterrupt(false);
+        #endif
       }
       else {
         modbus.sendErrorResponse(functionCode, ERROR_ILLEGAL_ADDRESS);
@@ -774,6 +821,7 @@ ISR(PCINT2_vect) {
     pulse1LastValue = true;
   }
   
+  #ifndef ENABLE_EXT_INTERRUPT
   if (!digitalRead(P2_PIN) && pulse2LastValue) {
     if ((millis() - pulse2LastFall) > (uint32_t)PULSE_MIN) {
       gwMetaData.pulse2++;
@@ -784,11 +832,14 @@ ISR(PCINT2_vect) {
   else if (digitalRead(P2_PIN) && !pulse2LastValue) {
     pulse2LastValue = true;
   }
+  #endif
 }
 
 void savePulsesToEEPROM() {
   EEPROM.put(10, gwMetaData.pulse1);
+  #ifndef ENABLE_EXT_INTERRUPT
   EEPROM.put(20, gwMetaData.pulse2);
+  #endif
   if (!hasNTC) {
     EEPROM.put(30, gwMetaData.pulse3);
   }
@@ -796,7 +847,9 @@ void savePulsesToEEPROM() {
 
 void readPulsesFromEEPROM() {
   EEPROM.get(10, gwMetaData.pulse1);
+  #ifndef ENABLE_EXT_INTERRUPT
   EEPROM.get(20, gwMetaData.pulse2);
+  #endif
   if (!hasNTC) {
     EEPROM.get(30, gwMetaData.pulse3);
   }
@@ -813,6 +866,23 @@ void clearPulsesFromEEPROM() {
 void readNTC() {
   gwMetaData.pulse3 = sensorNTC.readTemperature();
 }
+
+#ifdef ENABLE_EXT_INTERRUPT
+void setExternalInterrupt(bool status) {
+  if (status) {
+    #ifdef EXT_INTERRUPT_USE_INT_PULLUP
+    digitalWrite(P2_PIN, LOW);
+    #endif
+    pinMode(P2_PIN, OUTPUT);
+  }
+  else {
+    pinMode(P2_PIN, INPUT);
+    #ifdef EXT_INTERRUPT_USE_INT_PULLUP
+    digitalWrite(P2_PIN, HIGH);
+    #endif
+  }
+}
+#endif
 
 void startUp() {
   digitalWrite(LED_PIN, HIGH);

--- a/SensorsGateway/SensorsGateway.ino
+++ b/SensorsGateway/SensorsGateway.ino
@@ -64,9 +64,9 @@
  * Define EXT_INTERRUPT_USE_INT_PULLUP to use internal (weak) Atmega328P pull-up resistor, otherwise
  * make sure to have pull-up resistor in the upstream device.
  */
-#define ENABLE_EXT_INTERRUPT
-#define EXT_INTERRUPT_ONLY_IMPORTANT
-#define EXT_INTERRUPT_USE_INT_PULLUP
+//#define ENABLE_EXT_INTERRUPT
+//#define EXT_INTERRUPT_ONLY_IMPORTANT
+//#define EXT_INTERRUPT_USE_INT_PULLUP
 
 /*
  * ####################

--- a/SensorsGateway/SensorsGateway.ino
+++ b/SensorsGateway/SensorsGateway.ino
@@ -56,7 +56,7 @@
 /*
  * ### EXTERNAL INTERRUPT ###
  *
- * Select if pulse 2 is used as an interrupt to inform upstream device of new messages.
+ * Select if pulse 2 is used as an open drain active low output to inform upstream device of new messages.
  *
  * Define ENABLE_EXT_INTERRUPT if you want this feature to be enabled, otherwise comment it out.
  * Define EXT_INTERRUPT_ONLY_IMPORTANT if you want that only nodes which declare themselves as important

--- a/SensorsPulse/SensorsPulse.ino
+++ b/SensorsPulse/SensorsPulse.ino
@@ -227,7 +227,7 @@ void setup() {
   
   // Delay so that if button was pressed for debug mode but EEPROM is not to be cleared,
   // user has some time to release the button.
-  delay(1000);
+  delay(2000);
   
   // If jumper is set and button pressed, clear pulse values from EEPROM.
   if (!digitalRead(JMP_PIN) && !digitalRead(BTN_PIN)) {

--- a/SensorsPulse/SensorsPulse.ino
+++ b/SensorsPulse/SensorsPulse.ino
@@ -369,6 +369,11 @@ bool constructAndSendPacket() {
   #elif defined NODE_TYPE_PULSE
   payloadBuffer[0] = B00000011;
   #endif
+  
+  if (isImportant) {
+    payloadBuffer[0] |= B00100000;
+  }
+  
   payloadBuffer[1] = transmitPowerRaw;
   payloadBuffer[2] = transmitInterval;
   


### PR DESCRIPTION
Adds:
* External interrupt to gateway.
* ID of the last received node to gateway Modbus registers.
* Importance setting to battery/pulse nodes.

Refines and updates readme with regards to previous points. Also has some general cleaning and clarification of readme.

Closes #2 